### PR TITLE
Implement the Client loop

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,8 @@ GEM
     docile (1.1.5)
     domain_name (0.5.25)
       unf (>= 0.0.5, < 1.0.0)
+    factory_girl (4.5.0)
+      activesupport (>= 3.0.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.10.0)
@@ -92,6 +94,7 @@ DEPENDENCIES
   codeclimate-test-reporter
   coursemology-evaluator!
   coveralls
+  factory_girl
   rake
   rspec
   simplecov

--- a/coursemology-evaluator.gemspec
+++ b/coursemology-evaluator.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'factory_girl'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'codeclimate-test-reporter'

--- a/lib/coursemology/evaluator/cli.rb
+++ b/lib/coursemology/evaluator/cli.rb
@@ -1,7 +1,7 @@
 require 'optparse'
 
 class Coursemology::Evaluator::CLI
-  Options = Struct.new(:host, :api_token, :api_user_email)
+  Options = Struct.new(:host, :api_token, :api_user_email, :one_shot)
 
   def self.start(argv)
     new.start(argv)
@@ -15,7 +15,7 @@ class Coursemology::Evaluator::CLI
     options = optparse!(argv)
     Coursemology::Evaluator::Client.initialize(options.host, options.api_user_email,
                                                options.api_token)
-    Coursemology::Evaluator::Client.new.run
+    Coursemology::Evaluator::Client.new(options.one_shot).run
   end
 
   private
@@ -38,6 +38,10 @@ class Coursemology::Evaluator::CLI
 
       parser.on('-uUSER', '--api-user-email=USER') do |user|
         options.api_user_email = user
+      end
+
+      parser.on('-o', '--one-shot') do
+        options.one_shot = true
       end
     end
 

--- a/lib/coursemology/evaluator/client.rb
+++ b/lib/coursemology/evaluator/client.rb
@@ -8,8 +8,50 @@ class Coursemology::Evaluator::Client
   end
 
   def initialize
+    @terminate = false
   end
 
   def run
+    Signal.trap('SIGTERM', method(:on_sig_term))
+
+    loop do
+      if @terminate
+        break
+      else
+        allocate_evaluations
+        sleep(1.minute)
+      end
+    end
+  end
+
+  private
+
+  # Requests evaluations from the server.
+  def allocate_evaluations
+    evaluations = Coursemology::Evaluator::Models::ProgrammingEvaluation.allocate
+    on_allocate(evaluations)
+  end
+
+  # The callback for handling an array of allocated evaluations.
+  #
+  # @param [Array<Coursemology::Evaluator::Models::ProgrammingEvaluation>] evaluations The
+  #   evaluations retrieved from the server.
+  def on_allocate(evaluations)
+    evaluations.each do |evaluation|
+      on_evaluation(evaluation)
+    end
+  end
+
+  # The callback for handling an evaluation.
+  #
+  # @param [Coursemology::Evaluator::Models::ProgrammingEvaluation] evaluation The evaluation
+  #   retrieved from the server.
+  def on_evaluation(evaluation)
+    evaluation.save
+  end
+
+  # The callback for handling SIGTERM sent to the process.
+  def on_sig_term
+    @terminate = true
   end
 end

--- a/lib/coursemology/evaluator/client.rb
+++ b/lib/coursemology/evaluator/client.rb
@@ -7,20 +7,19 @@ class Coursemology::Evaluator::Client
     Coursemology::Evaluator::Models::Base.initialize
   end
 
-  def initialize
-    @terminate = false
+  # @param [Boolean] one_shot If the client should only fire one request.
+  def initialize(one_shot = false)
+    @terminate = one_shot
   end
 
   def run
     Signal.trap('SIGTERM', method(:on_sig_term))
 
     loop do
-      if @terminate
-        break
-      else
-        allocate_evaluations
-        sleep(1.minute)
-      end
+      allocate_evaluations
+      break if @terminate
+
+      sleep(1.minute)
     end
   end
 

--- a/spec/coursemology/evaluator/cli_spec.rb
+++ b/spec/coursemology/evaluator/cli_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe Coursemology::Evaluator::CLI do
   let(:api_token) { 'abcd' }
   let(:api_user_email) { 'test@example.org' }
   let(:argv) do
-    ["--host=#{host}", "--api-token=#{api_token}", "--api-user-email=#{api_user_email}"]
+    ["--host=#{host}", "--api-token=#{api_token}", "--api-user-email=#{api_user_email}",
+     '--one-shot']
   end
 
   describe Coursemology::Evaluator::CLI::Options do
@@ -33,14 +34,17 @@ RSpec.describe Coursemology::Evaluator::CLI do
       subject { Coursemology::Evaluator::CLI.new.run(argv) }
 
       it 'creates a client' do
-        mock_client = double(run: nil)
-        expect(Coursemology::Evaluator::Client).to receive(:new).and_return(mock_client)
-        subject
+        expect(Coursemology::Evaluator::Client).to receive(:new).and_call_original
+        VCR.use_cassette('client/no_pending_evaluations') do
+          subject
+        end
       end
 
       it 'runs the client' do
         expect(Coursemology::Evaluator::Client).to receive_message_chain(:new, :run)
-        subject
+        VCR.use_cassette('client/no_pending_evaluations') do
+          subject
+        end
       end
     end
   end

--- a/spec/coursemology/evaluator/cli_spec.rb
+++ b/spec/coursemology/evaluator/cli_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe Coursemology::Evaluator::CLI do
   let(:host) { 'http://localhost:3000' }
+  let!(:original_api_token) { Coursemology::Evaluator::Models::Base.api_token }
   let(:api_token) { 'abcd' }
   let(:api_user_email) { 'test@example.org' }
   let(:argv) do
@@ -22,16 +23,18 @@ RSpec.describe Coursemology::Evaluator::CLI do
     describe '#start' do
       subject { Coursemology::Evaluator::CLI.new }
       it 'calls #run' do
-        expect(subject).to receive(:run).and_call_original
+        expect(subject).to receive(:run)
         subject.start(argv)
       end
     end
 
     describe '#run' do
+      let(:api_token) { original_api_token }
       subject { Coursemology::Evaluator::CLI.new.run(argv) }
 
       it 'creates a client' do
-        expect(Coursemology::Evaluator::Client).to receive(:new).and_call_original
+        mock_client = double(run: nil)
+        expect(Coursemology::Evaluator::Client).to receive(:new).and_return(mock_client)
         subject
       end
 

--- a/spec/factories/programming_evaluations.rb
+++ b/spec/factories/programming_evaluations.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :programming_evaluation, class: Coursemology::Evaluator::Models::ProgrammingEvaluation do
+    id 1
+    language 'Polyglot::Language::Python::Python2Point7'
+    memory_limit 32
+    time_limit 5
+  end
+end

--- a/spec/fixtures/vcr/cassettes/client/no_pending_evaluations.yml
+++ b/spec/fixtures/vcr/cassettes/client/no_pending_evaluations.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:3000/courses/assessment/programming_evaluations/allocate
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - ActiveRestClient/1.2.0
+      Connection:
+      - Keep-Alive
+      Accept:
+      - application/hal+json, application/json;q=0.5
+      X-User-Email:
+      - test@example.org
+      X-User-Token:
+      - YOUR_TOKEN_HERE
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      content-type:
+      - application/json; charset=utf-8
+      cache-control:
+      - no-store, must-revalidate, private, max-age=0
+      x-request-id:
+      - 56109927-259f-413d-8dbb-95f02dc1e3e7
+      x-runtime:
+      - '0.580646'
+      x-miniprofiler-ids:
+      - '["g61697empnv3cyhwvvlu","sv2daht3quq3ti4jvvg5","uv84uouoadr9cjoxx5df","vzn03ouf207zi8ixeyqu","ezc78yubvk6fv8mnklhu","5rc1ta39wdyj0fv8dh6z","w05805bb6qbjhekuariy","8wynqvhb8fmrem7vo261","vr7hm3zpbq6ftrubgyqj","ow31gd85uwp55l8a5vnq"]'
+      server:
+      - WEBrick/1.3.1 (Ruby/2.2.4/2015-10-06)
+      date:
+      - Tue, 22 Dec 2015 01:22:30 GMT
+      content-length:
+      - '2'
+      connection:
+      - Keep-Alive
+      set-cookie:
+      - __profilin=p%3Dt; path=/, __profilin=p%3Dt; path=/, __profilin=p%3Dt; path=/
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Tue, 22 Dec 2015 01:22:30 GMT
+recorded_with: VCR 3.0.0

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,0 +1,9 @@
+require 'factory_girl'
+
+RSpec.configure do |config|
+  config.include FactoryGirl::Syntax::Methods
+
+  config.before(:suite) do
+    FactoryGirl.find_definitions
+  end
+end


### PR DESCRIPTION
This will keep running the client and wait for new pending evaluations from the server.

New command line argument `--one-shot` to only poll the server once, then immediately quit.