### PR TITLE
Implement a trivial Docker::Image cache.

### DIFF
--- a/spec/coursemology/evaluator/client_spec.rb
+++ b/spec/coursemology/evaluator/client_spec.rb
@@ -61,10 +61,13 @@ RSpec.describe Coursemology::Evaluator::Client do
   end
 
   describe '#on_evaluation' do
-    let(:dummy_evaluation) { build(:programming_evaluation) }
+    let(:dummy_evaluation) do
+      build(:programming_evaluation).tap do |dummy_evaluation|
+        expect(dummy_evaluation).to receive(:evaluate)
+      end
+    end
 
     it 'evaluates the evaluation' do
-      expect(dummy_evaluation).to receive(:evaluate)
       subject.send(:on_evaluation, dummy_evaluation)
     end
 

--- a/spec/coursemology/evaluator/services/evaluate_programming_package_service_spec.rb
+++ b/spec/coursemology/evaluator/services/evaluate_programming_package_service_spec.rb
@@ -26,9 +26,6 @@ RSpec.describe Coursemology::Evaluator::Services::EvaluateProgrammingPackageServ
     end
 
     it 'instruments the creation' do
-      expect(Docker::Image).to receive(:create)
-      expect(Docker::Container).to receive(:create)
-
       expect { subject.send(:create_container, image) }.to \
         instrument_notification('create.docker.evaluator.coursemology')
     end
@@ -110,11 +107,10 @@ RSpec.describe Coursemology::Evaluator::Services::EvaluateProgrammingPackageServ
   end
 
   describe '#destroy_container' do
-    it 'instruments the destruction' do
-      container = double
-      allow(container).to receive(:delete)
-      allow(container).to receive(:id).and_return('')
+    let(:image) { 'python:2.7' }
+    let(:container) { subject.send(:create_container, image) }
 
+    it 'instruments the destruction' do
       expect { subject.send(:destroy_container, container) }.to \
         instrument_notification('destroy.docker.evaluator.coursemology')
     end

--- a/spec/support/docker_images.rb
+++ b/spec/support/docker_images.rb
@@ -1,0 +1,11 @@
+# This caches the results of pulling from Docker Hub for the duration of the test session.
+module DockerImageCache
+  def create(hash)
+    return super unless hash['fromImage']
+
+    @cache ||= {}
+    @cache[hash['fromImage']] ||= super
+  end
+end
+
+Docker::Image.singleton_class.send(:prepend, DockerImageCache)


### PR DESCRIPTION
This prevents repeated hits to Docker Hub when running the specs. This *does not* affect production runs.