### PR TITLE
Do not cover calls to sleep in the event loop.

### DIFF
--- a/lib/coursemology/evaluator/client.rb
+++ b/lib/coursemology/evaluator/client.rb
@@ -19,7 +19,11 @@ class Coursemology::Evaluator::Client
       allocate_evaluations
       break if @terminate
 
+      # :nocov:
+      # This sleep might not be triggered in the specs, because interruptions to the thread is
+      # nondeterministically run by the OS scheduler.
       sleep(1.minute)
+      # :nocov:
     end
   end
 


### PR DESCRIPTION
Interruptions from the OS might be nondeterministic.