### PR TITLE
Evaluator start command changed to just `evaluator`.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-evaluator: ruby bin/evaluator --host=$HOST --api-token=$API_TOKEN --api-user-email=$API_USER_EMAIL
+evaluator: evaluator --host=$HOST --api-token=$API_TOKEN --api-user-email=$API_USER_EMAIL


### PR DESCRIPTION
Using gem install as root or a normal user do not place the evaluator
script in a location accessible with `bin/evaluator` without modifying
$PATH.