### PR TITLE
Update Flexirest.

### DIFF
--- a/coursemology-evaluator.gemspec
+++ b/coursemology-evaluator.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'vcr'
 
   spec.add_dependency 'activesupport', '~> 4.2.0', '>= 4.2.2'
-  spec.add_dependency 'flexirest', '~> 1.2'
+  spec.add_dependency 'flexirest', '~> 1.2', '>= 1.2.6'
   spec.add_dependency 'faraday_middleware'
 
   spec.add_dependency 'coursemology-polyglot', '>= 0.0.3'

--- a/lib/coursemology/evaluator/models/programming_evaluation.rb
+++ b/lib/coursemology/evaluator/models/programming_evaluation.rb
@@ -34,7 +34,8 @@ class Coursemology::Evaluator::Models::ProgrammingEvaluation < Coursemology::Eva
   # @return [Coursemology::Evaluator::Models::ProgrammingEvaluation::Package]
   def package
     @package ||= begin
-      body = plain_request('courses/assessment/programming_evaluations/:id/package', id: id)
+      body = self.class._plain_request('courses/assessment/programming_evaluations/:id/package',
+                                       :get, id: id)
       Package.new(Coursemology::Evaluator::StringIO.new(body))
     end
   end
@@ -50,18 +51,5 @@ class Coursemology::Evaluator::Models::ProgrammingEvaluation < Coursemology::Eva
     self.stderr = result.stderr
     self.test_report = result.test_report
     self.exit_code = result.exit_code
-  end
-
-  private
-
-  # Performs a plain request.
-  #
-  # @param [String] url The URL to request.
-  # @param [Hash] params The parameter to be part of the request.
-  # @return [String] The response body.
-  def plain_request(url, params = {})
-    request = Flexirest::Request.new({ url: url, method: :get, options: { plain: true } },
-                                     self.class)
-    request.call(params)
   end
 end

--- a/spec/coursemology/evaluator/models/programming_evaluation_spec.rb
+++ b/spec/coursemology/evaluator/models/programming_evaluation_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Coursemology::Evaluator::Models::ProgrammingEvaluation do
 
     it 'memoises its result' do
       VCR.use_cassette 'programming_evaluation/package' do
-        expect(evaluation).to receive(:plain_request).and_call_original
+        expect(evaluation.class).to receive(:_plain_request).and_call_original
         evaluation.package
         evaluation.package
       end


### PR DESCRIPTION
This brings a `_plain_request` which supports variable substitution.