### PR TITLE
Implement caching checks for updated Docker images.

### DIFF
--- a/lib/coursemology/evaluator.rb
+++ b/lib/coursemology/evaluator.rb
@@ -28,6 +28,9 @@ module Coursemology::Evaluator
   # The logger to use for the client.
   mattr_reader(:logger) { ActiveSupport::Logger.new(STDOUT) }
 
+  # The cache to use for the client.
+  mattr_reader(:cache) { ActiveSupport::Cache.lookup_store }
+
   def self.eager_load!
     super
     Coursemology::Polyglot.eager_load!

--- a/lib/coursemology/evaluator/logging/docker_log_subscriber.rb
+++ b/lib/coursemology/evaluator/logging/docker_log_subscriber.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 class Coursemology::Evaluator::Logging::DockerLogSubscriber < ActiveSupport::LogSubscriber
   def pull(event)
-    info "#{color("Docker Pull (#{event.duration.round(1)}ms)", GREEN)} #{event.payload[:image]}"
+    cached = event.payload[:cached].nil? || event.payload[:cached] ? 'Cached ' : ''
+    header_colour = cached ? GREEN : YELLOW
+    info "#{color("#{cached}Docker Pull (#{event.duration.round(1)}ms)", header_colour)} "\
+      "#{event.payload[:image]}"
   end
 
   def create(event)

--- a/spec/coursemology/evaluator/docker_container_spec.rb
+++ b/spec/coursemology/evaluator/docker_container_spec.rb
@@ -15,6 +15,24 @@ RSpec.describe Coursemology::Evaluator::DockerContainer do
     end
   end
 
+  describe '.cached' do
+    let(:delete_subject) { false }
+    subject { Coursemology::Evaluator::DockerContainer }
+
+    it 'caches the call' do
+      calls = 0
+      cache_options = { expires_in: 1.second }
+      cache_miss_block = proc { calls += 1 }
+      subject.send(:cached, :test, cache_options, &cache_miss_block)
+      subject.send(:cached, :test, cache_options, &cache_miss_block)
+      expect(calls).to eq(1)
+      sleep(1.second)
+
+      subject.send(:cached, :test, cache_options, &cache_miss_block)
+      expect(calls).to eq(2)
+    end
+  end
+
   describe '#wait' do
     it 'retries until the container finishes' do
       subject.start!


### PR DESCRIPTION
Checking for new images adds almost 5 seconds of overhead. We now only check for new images every 5 minutes.