### PR TITLE
Specify Docker version for Travis builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,7 @@ bundler_args: "--jobs=3 --retry=3"
 cache: bundler
 
 before_install:
+  - sudo apt-get update
+  - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine=1.10.3-0~trusty
   - gem install bundler
+  - docker version


### PR DESCRIPTION
Tests do not pass on Docker API versions greater than 1.22 due to #49. Until that is fixed upstream, this PR installs a Docker 1.10.3, which has API version 1.22.

Instructions were from http://graysonkoonce.com/managing-docker-and-docker-compose-versions-on-travis-ci/