### PR TITLE
Allow poll interval to be specified from the command line.

### DIFF
--- a/coursemology-evaluator.gemspec
+++ b/coursemology-evaluator.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'vcr'
 
   spec.add_dependency 'activesupport', '~> 4.2.0', '>= 4.2.2'
+  spec.add_dependency 'iso8601', '~> 0.9.1'
   spec.add_dependency 'flexirest', '~> 1.2', '>= 1.2.6'
   spec.add_dependency 'faraday_middleware'
 

--- a/lib/coursemology/evaluator.rb
+++ b/lib/coursemology/evaluator.rb
@@ -9,6 +9,7 @@ Docker.validate_version!
 require 'coursemology/polyglot'
 require 'coursemology/polyglot/extensions'
 require 'coursemology/evaluator/version'
+require 'iso8601'
 
 module Coursemology::Evaluator
   extend ActiveSupport::Autoload

--- a/lib/coursemology/evaluator/cli.rb
+++ b/lib/coursemology/evaluator/cli.rb
@@ -2,7 +2,7 @@
 require 'optparse'
 
 class Coursemology::Evaluator::CLI
-  Options = Struct.new(:host, :api_token, :api_user_email, :one_shot)
+  Options = Struct.new(:host, :api_token, :api_user_email, :one_shot, :poll_interval)
 
   def self.start(argv)
     new.start(argv)
@@ -16,7 +16,7 @@ class Coursemology::Evaluator::CLI
     options = optparse!(argv)
     Coursemology::Evaluator::Client.initialize(options.host, options.api_user_email,
                                                options.api_token)
-    Coursemology::Evaluator::Client.new(options.one_shot).run
+    Coursemology::Evaluator::Client.new(options.one_shot, options.poll_interval).run
   end
 
   private
@@ -27,6 +27,11 @@ class Coursemology::Evaluator::CLI
   # @return [Coursemology::Evaluator::CLI::Options]
   def optparse!(argv) # rubocop:disable Metrics/MethodLength
     options = Options.new
+
+    # default options for optional parameters
+    options.poll_interval = '10S'
+    options.one_shot = false
+
     option_parser = OptionParser.new do |parser|
       parser.banner = "Usage: #{parser.program_name} [options]"
       parser.on('-hHOST', '--host=HOST', 'Coursemology host to connect to') do |host|
@@ -39,6 +44,10 @@ class Coursemology::Evaluator::CLI
 
       parser.on('-uUSER', '--api-user-email=USER') do |user|
         options.api_user_email = user
+      end
+
+      parser.on('-iINTERVAL', '--interval=INTERVAL') do |interval|
+        options.poll_interval = interval
       end
 
       parser.on('-o', '--one-shot') do

--- a/lib/coursemology/evaluator/client.rb
+++ b/lib/coursemology/evaluator/client.rb
@@ -9,7 +9,10 @@ class Coursemology::Evaluator::Client
   end
 
   # @param [Boolean] one_shot If the client should only fire one request.
-  def initialize(one_shot = false)
+  # @param [Float] poll_time Sleep time between checks for task allocation.
+  # @param [String] poll_interval Units for poll_time.
+  def initialize(one_shot = false, poll_interval = '10S')
+    @poll_interval = ::ISO8601::Duration.new("PT#{poll_interval}".upcase)
     @terminate = one_shot
   end
 
@@ -31,7 +34,7 @@ class Coursemology::Evaluator::Client
       # :nocov:
       # This sleep might not be triggered in the specs, because interruptions to the thread is
       # nondeterministically run by the OS scheduler.
-      sleep(1.minute)
+      sleep(@poll_interval.to_seconds)
       # :nocov:
     end
 

--- a/spec/coursemology/evaluator/cli_spec.rb
+++ b/spec/coursemology/evaluator/cli_spec.rb
@@ -4,13 +4,21 @@ RSpec.describe Coursemology::Evaluator::CLI do
   let!(:original_api_token) { Coursemology::Evaluator::Models::Base.api_token }
   let(:api_token) { 'abcd' }
   let(:api_user_email) { 'test@example.org' }
+  let(:poll_interval) { '10S' }
   let(:argv) do
+    ["--host=#{host}", "--api-token=#{api_token}", "--api-user-email=#{api_user_email}",
+     '--one-shot', "--interval=#{poll_interval}"]
+  end
+  let(:argv_missing) do
     ["--host=#{host}", "--api-token=#{api_token}", "--api-user-email=#{api_user_email}",
      '--one-shot']
   end
 
   describe Coursemology::Evaluator::CLI::Options do
-    it { is_expected.to have_attributes(host: nil, api_token: nil, api_user_email: nil) }
+    it 'checks Options attributes' do
+      expect(subject).to have_attributes(host: nil, api_token: nil, api_user_email: nil,
+                                         poll_interval: nil)
+    end
   end
 
   with_mock_client do
@@ -69,6 +77,18 @@ RSpec.describe Coursemology::Evaluator::CLI do
 
     it 'parses api-user-email' do
       expect(subject.api_user_email).to eq(api_user_email)
+    end
+
+    it 'parses poll-interval' do
+      expect(subject.poll_interval).to eq(poll_interval)
+    end
+  end
+
+  describe '#optparse! defaults' do
+    subject { Coursemology::Evaluator::CLI.new.send(:optparse!, argv_missing) }
+
+    it 'sets default value for poll_interval' do
+      expect(subject.poll_interval).to eq('10S')
     end
   end
 end


### PR DESCRIPTION
Uses 10 seconds as the default.

Fixes #46.