### PR TITLE
Allow Docker image cache expiry to be specified from the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,26 @@ This is the evaluator program which will query Coursemology for pending evaluati
 
 3. Start the evaluator using the Procfile. You can use [foreman](https://github.com/ddollar/foreman)
    or any similar tool to generate system scripts for boot.
+
+### Command Line Options
+
+#### Compulsory Options
+
+1. `--host`: Coursemology host to connect to
+2. `--api-user-email`: User with autograder flag set
+3. `--api-token`: Authentication token of the user
+
+#### Optional Options
+
+Time options are expected to be strings in [ISO8601 format](https://en.wikipedia.org/wiki/ISO_8601#Durations).
+
+1. `--interval`: Time interval between checks for programming allocations. As this time is
+  expected to be short, specify it with the time components of ISO8601 only. (Hours, minutes, seconds)
+  The time designator `T` must be left out.
+
+2. `--lifetime`: Length of time to cache Docker images. This is expected to be in the order of days.
+  If more granularity is needed, the time designator is required.
+
+  E.g. `1DT2H5M10S`
+
+3. `--one-shot`: Runs once and terminates. Primarily used for testing.

--- a/lib/coursemology/evaluator.rb
+++ b/lib/coursemology/evaluator.rb
@@ -13,6 +13,7 @@ require 'iso8601'
 
 module Coursemology::Evaluator
   extend ActiveSupport::Autoload
+  include ActiveSupport::Configurable
 
   autoload :Client
   autoload :DockerContainer

--- a/lib/coursemology/evaluator/cli.rb
+++ b/lib/coursemology/evaluator/cli.rb
@@ -15,10 +15,16 @@ class Coursemology::Evaluator::CLI
 
   def run(argv)
     options = optparse!(argv)
+    Coursemology::Evaluator.config.poll_interval =
+      ::ISO8601::Duration.new("PT#{options.poll_interval}".upcase).to_seconds
+
+    # Must include the time designator T if hours/minutes/seconds are required.
+    Coursemology::Evaluator.config.image_lifetime =
+      ::ISO8601::Duration.new("P#{options.image_lifetime}".upcase).to_seconds
 
     Coursemology::Evaluator::Client.initialize(options.host, options.api_user_email,
                                                options.api_token)
-    Coursemology::Evaluator::Client.new(options.one_shot, options.poll_interval).run
+    Coursemology::Evaluator::Client.new(options.one_shot).run
   end
 
   private
@@ -32,7 +38,7 @@ class Coursemology::Evaluator::CLI
 
     # default options for optional parameters
     options.poll_interval = '10S'
-    options.cache_expiry = '1D'
+    options.image_lifetime = '1D'
     options.one_shot = false
 
     option_parser = OptionParser.new do |parser|
@@ -53,8 +59,8 @@ class Coursemology::Evaluator::CLI
         options.poll_interval = interval
       end
 
-      parser.on('-eEXPIRY', '--expiry=EXPIRY') do |expiry|
-        options.cache_expiry = expiry
+      parser.on('-lLIFETIME', '--lifetime=LIFETIME') do |lifetime|
+        options.image_lifetime = lifetime
       end
 
       parser.on('-o', '--one-shot') do

--- a/lib/coursemology/evaluator/cli.rb
+++ b/lib/coursemology/evaluator/cli.rb
@@ -2,7 +2,8 @@
 require 'optparse'
 
 class Coursemology::Evaluator::CLI
-  Options = Struct.new(:host, :api_token, :api_user_email, :one_shot, :poll_interval)
+  Options = Struct.new(:host, :api_token, :api_user_email,
+                       :one_shot, :poll_interval, :image_lifetime)
 
   def self.start(argv)
     new.start(argv)
@@ -14,6 +15,7 @@ class Coursemology::Evaluator::CLI
 
   def run(argv)
     options = optparse!(argv)
+
     Coursemology::Evaluator::Client.initialize(options.host, options.api_user_email,
                                                options.api_token)
     Coursemology::Evaluator::Client.new(options.one_shot, options.poll_interval).run
@@ -30,6 +32,7 @@ class Coursemology::Evaluator::CLI
 
     # default options for optional parameters
     options.poll_interval = '10S'
+    options.cache_expiry = '1D'
     options.one_shot = false
 
     option_parser = OptionParser.new do |parser|
@@ -48,6 +51,10 @@ class Coursemology::Evaluator::CLI
 
       parser.on('-iINTERVAL', '--interval=INTERVAL') do |interval|
         options.poll_interval = interval
+      end
+
+      parser.on('-eEXPIRY', '--expiry=EXPIRY') do |expiry|
+        options.cache_expiry = expiry
       end
 
       parser.on('-o', '--one-shot') do

--- a/lib/coursemology/evaluator/client.rb
+++ b/lib/coursemology/evaluator/client.rb
@@ -9,10 +9,7 @@ class Coursemology::Evaluator::Client
   end
 
   # @param [Boolean] one_shot If the client should only fire one request.
-  # @param [Float] poll_time Sleep time between checks for task allocation.
-  # @param [String] poll_interval Units for poll_time.
-  def initialize(one_shot = false, poll_interval = '10S')
-    @poll_interval = ::ISO8601::Duration.new("PT#{poll_interval}".upcase)
+  def initialize(one_shot = false)
     @terminate = one_shot
   end
 
@@ -34,7 +31,7 @@ class Coursemology::Evaluator::Client
       # :nocov:
       # This sleep might not be triggered in the specs, because interruptions to the thread is
       # nondeterministically run by the OS scheduler.
-      sleep(@poll_interval.to_seconds)
+      sleep(Coursemology::Evaluator.config.poll_interval)
       # :nocov:
     end
 

--- a/lib/coursemology/evaluator/docker_container.rb
+++ b/lib/coursemology/evaluator/docker_container.rb
@@ -17,13 +17,14 @@ class Coursemology::Evaluator::DockerContainer < Docker::Container
 
     # Pulls the given image from Docker Hub.
     #
-    # This caches images for 5 minutes, because the overhead for querying for images is quite high.
+    # This caches images for the specified time, because the overhead for querying
+    # for images is quite high.
     #
     # @param [String] image The image to pull.
     def pull_image(image)
       ActiveSupport::Notifications.instrument('pull.docker.evaluator.coursemology',
                                               image: image) do |payload|
-        cached([:image, image], expires_in: 5.minutes) do
+        cached([:image, image], expires_in: Coursemology::Evaluator.config.image_lifetime) do
           Docker::Image.create('fromImage' => image)
           payload[:cached] = false
         end

--- a/spec/coursemology/evaluator/cli_spec.rb
+++ b/spec/coursemology/evaluator/cli_spec.rb
@@ -4,10 +4,11 @@ RSpec.describe Coursemology::Evaluator::CLI do
   let!(:original_api_token) { Coursemology::Evaluator::Models::Base.api_token }
   let(:api_token) { 'abcd' }
   let(:api_user_email) { 'test@example.org' }
-  let(:poll_interval) { '10S' }
+  let(:poll_interval) { '20S' }
+  let(:cache_expiry) { '2D' }
   let(:argv) do
     ["--host=#{host}", "--api-token=#{api_token}", "--api-user-email=#{api_user_email}",
-     '--one-shot', "--interval=#{poll_interval}"]
+     '--one-shot', "--interval=#{poll_interval}", "--expiry=#{cache_expiry}"]
   end
   let(:argv_missing) do
     ["--host=#{host}", "--api-token=#{api_token}", "--api-user-email=#{api_user_email}",
@@ -17,7 +18,7 @@ RSpec.describe Coursemology::Evaluator::CLI do
   describe Coursemology::Evaluator::CLI::Options do
     it 'checks Options attributes' do
       expect(subject).to have_attributes(host: nil, api_token: nil, api_user_email: nil,
-                                         poll_interval: nil)
+                                         poll_interval: nil, cache_expiry: nil)
     end
   end
 
@@ -82,6 +83,10 @@ RSpec.describe Coursemology::Evaluator::CLI do
     it 'parses poll-interval' do
       expect(subject.poll_interval).to eq(poll_interval)
     end
+
+    it 'parses cache-expiry' do
+      expect(subject.cache_expiry).to eq(cache_expiry)
+    end
   end
 
   describe '#optparse! defaults' do
@@ -89,6 +94,10 @@ RSpec.describe Coursemology::Evaluator::CLI do
 
     it 'sets default value for poll_interval' do
       expect(subject.poll_interval).to eq('10S')
+    end
+
+    it 'sets default value for cache_expiry' do
+      expect(subject.cache_expiry).to eq('1D')
     end
   end
 end

--- a/spec/coursemology/evaluator/cli_spec.rb
+++ b/spec/coursemology/evaluator/cli_spec.rb
@@ -5,10 +5,10 @@ RSpec.describe Coursemology::Evaluator::CLI do
   let(:api_token) { 'abcd' }
   let(:api_user_email) { 'test@example.org' }
   let(:poll_interval) { '20S' }
-  let(:cache_expiry) { '2D' }
+  let(:image_lifetime) { '2D' }
   let(:argv) do
     ["--host=#{host}", "--api-token=#{api_token}", "--api-user-email=#{api_user_email}",
-     '--one-shot', "--interval=#{poll_interval}", "--expiry=#{cache_expiry}"]
+     '--one-shot', "--interval=#{poll_interval}", "--lifetime=#{image_lifetime}"]
   end
   let(:argv_missing) do
     ["--host=#{host}", "--api-token=#{api_token}", "--api-user-email=#{api_user_email}",
@@ -18,7 +18,7 @@ RSpec.describe Coursemology::Evaluator::CLI do
   describe Coursemology::Evaluator::CLI::Options do
     it 'checks Options attributes' do
       expect(subject).to have_attributes(host: nil, api_token: nil, api_user_email: nil,
-                                         poll_interval: nil, cache_expiry: nil)
+                                         poll_interval: nil, image_lifetime: nil)
     end
   end
 
@@ -57,6 +57,20 @@ RSpec.describe Coursemology::Evaluator::CLI do
         end
       end
 
+      it 'sets poll interval in Evaluator configuration' do
+        VCR.use_cassette('client/no_pending_evaluations') do
+          subject
+        end
+        expect(Coursemology::Evaluator.config.poll_interval).to eq(20)
+      end
+
+      it 'sets Docker image lifetime in Evaluator configuration' do
+        VCR.use_cassette('client/no_pending_evaluations') do
+          subject
+        end
+        expect(Coursemology::Evaluator.config.image_lifetime).to eq(60 * 60 * 24 * 2)
+      end
+
       it 'evaluates the package' do
         VCR.use_cassette('client/pending_evaluation') do
           subject
@@ -84,8 +98,8 @@ RSpec.describe Coursemology::Evaluator::CLI do
       expect(subject.poll_interval).to eq(poll_interval)
     end
 
-    it 'parses cache-expiry' do
-      expect(subject.cache_expiry).to eq(cache_expiry)
+    it 'parses image-lifetime' do
+      expect(subject.image_lifetime).to eq(image_lifetime)
     end
   end
 
@@ -96,8 +110,8 @@ RSpec.describe Coursemology::Evaluator::CLI do
       expect(subject.poll_interval).to eq('10S')
     end
 
-    it 'sets default value for cache_expiry' do
-      expect(subject.cache_expiry).to eq('1D')
+    it 'sets default value for image_lifetime' do
+      expect(subject.image_lifetime).to eq('1D')
     end
   end
 end

--- a/spec/coursemology/evaluator/client_spec.rb
+++ b/spec/coursemology/evaluator/client_spec.rb
@@ -19,27 +19,20 @@ RSpec.describe Coursemology::Evaluator::Client do
 
   describe '#run' do
     let(:dummy_evaluation) { build_stubbed(:programming_evaluation) }
+    let(:poll_time) { 300 }
 
-    context 'with custom poll time' do
-      # Client with custom poll interval
-      let(:one_shot) { false }
-      let(:poll_interval) { '5m' }
-      subject(:custom_poll) do
-        Coursemology::Evaluator::Client.new(one_shot, poll_interval)
+    it 'sleeps with the configured poll time' do
+      Coursemology::Evaluator.config.poll_interval = poll_time
+      # Simulate no evaluations
+      expect(subject).to receive(:allocate_evaluations) { [] }
+
+      # Stub sleep to terminate after 1 mock sleep
+      allow(subject).to receive(:sleep) do
+        subject.instance_variable_set(:@terminate, true)
       end
 
-      it 'sleeps with a specified poll time' do
-        # Simulate no evaluations
-        expect(custom_poll).to receive(:allocate_evaluations) { [] }
-
-        # Stub sleep to terminate after 1 mock sleep
-        allow(custom_poll).to receive(:sleep) do
-          custom_poll.instance_variable_set(:@terminate, true)
-        end
-
-        expect(custom_poll).to receive(:sleep).with(300)
-        custom_poll.run
-      end
+      expect(subject).to receive(:sleep).with(poll_time)
+      subject.run
     end
 
     it 'loops until @terminate is set' do
@@ -58,19 +51,6 @@ RSpec.describe Coursemology::Evaluator::Client do
 
       expect(subject).to receive(:on_allocate).with([dummy_evaluation]).at_least(:once)
       Thread.new { subject.send(:on_sig_term) }
-      subject.run
-    end
-
-    it 'sleeps with the default poll time' do
-      # Simulate no evaluations
-      expect(subject).to receive(:allocate_evaluations) { [] }
-
-      # Stub sleep to terminate after 1 mock sleep
-      allow(subject).to receive(:sleep) do
-        subject.instance_variable_set(:@terminate, true)
-      end
-
-      expect(subject).to receive(:sleep).with(10)
       subject.run
     end
   end


### PR DESCRIPTION
Also change poll interval configuration to use `ActiveSupport::Configurable`.

Fixes #47.