### PR TITLE
Update minimum docker-api version.

### DIFF
--- a/coursemology-evaluator.gemspec
+++ b/coursemology-evaluator.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday_middleware'
 
   spec.add_dependency 'coursemology-polyglot', '>= 0.0.3'
-  spec.add_dependency 'docker-api', '>= 1.2.5'
+  spec.add_dependency 'docker-api', '>= 1.29.1'
   spec.add_dependency 'rubyzip'
 end


### PR DESCRIPTION
This fix from https://github.com/swipely/docker-api/pull/418 is needed
or only Docker 1.10.x and below can be used.

Merge with #54 