### PR TITLE
Revert "Specify Docker version for Travis builds."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,4 @@ bundler_args: "--jobs=3 --retry=3"
 cache: bundler
 
 before_install:
-  - sudo apt-get update
-  - sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine=1.10.3-0~trusty
   - gem install bundler
-  - docker version


### PR DESCRIPTION
Reverts Coursemology/evaluator-slave#51.

Docker-api gem was fixed upstream.
https://github.com/swipely/docker-api/pull/418