### PR TITLE
Force test report encoding to UTF-8.

### DIFF
--- a/lib/coursemology/evaluator/services/evaluate_programming_package_service.rb
+++ b/lib/coursemology/evaluator/services/evaluate_programming_package_service.rb
@@ -125,7 +125,7 @@ class Coursemology::Evaluator::Services::EvaluateProgrammingPackageService
 
     tar_file = Gem::Package::TarReader.new(stream)
     tar_file.each do |file|
-      return file.read
+      return file.read.force_encoding(Encoding::UTF_8)
     end
   rescue Docker::Error::NotFoundError
     return nil

--- a/lib/coursemology/evaluator/version.rb
+++ b/lib/coursemology/evaluator/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 module Coursemology; end
 module Coursemology::Evaluator
-  VERSION = '0.1.5'.freeze
+  VERSION = '0.1.7'.freeze
 end

--- a/spec/coursemology/evaluator/services/evaluate_programming_package_service_spec.rb
+++ b/spec/coursemology/evaluator/services/evaluate_programming_package_service_spec.rb
@@ -120,7 +120,9 @@ RSpec.describe Coursemology::Evaluator::Services::EvaluateProgrammingPackageServ
 
     it 'returns the test report' do
       copy_dummy_report
-      expect(subject.send(:extract_test_report, container)).to eq(report_contents)
+      test_report = subject.send(:extract_test_report, container)
+      expect(test_report).to eq(report_contents)
+      expect(test_report.encoding).to eq Encoding::UTF_8
     end
 
     context 'when running the tests fails' do


### PR DESCRIPTION
Originally ASCII-8BIT which causes problems for `to_json` later in the
Flexirest gem.

Fixes #59, fixes #58.