### PR TITLE
Retire this external evaluator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+[![No Maintenance Intended](http://unmaintained.tech/badge.svg)](http://unmaintained.tech/)
+
+Coursemology 2 now runs code evaluations directly and no longer needs an external evaluator.
+See [this issue](https://github.com/Coursemology/coursemology2/pull/2308).
+
 # Coursemology Code Evaluator [![Build Status](https://travis-ci.org/Coursemology/evaluator-slave.svg?branch=master)](https://travis-ci.org/Coursemology/evaluator-slave)
 [![Code Climate](https://codeclimate.com/github/Coursemology/evaluator-slave/badges/gpa.svg)](https://codeclimate.com/github/Coursemology/evaluator-slave) [![Coverage Status](https://coveralls.io/repos/Coursemology/evaluator-slave/badge.svg?branch=master&service=github)](https://coveralls.io/github/Coursemology/evaluator-slave?branch=master) [![Security](https://hakiri.io/github/Coursemology/evaluator-slave/master.svg)](https://hakiri.io/github/Coursemology/evaluator-slave/master) [![Inline docs](http://inch-ci.org/github/coursemology/evaluator-slave.svg?branch=master)](http://inch-ci.org/github/coursemology/evaluator-slave) [![Gem Version](https://badge.fury.io/rb/coursemology-evaluator.svg)](https://badge.fury.io/rb/coursemology-evaluator)
 


### PR DESCRIPTION
Add unmaintained badge and link to the PR that makes this evaluator redundant.